### PR TITLE
chore: rescope package to @zenyui

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 zenyui
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@troop.com/tiptap-react-render",
+  "name": "@zenyui/tiptap-react-render",
   "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@troop.com/tiptap-react-render",
+      "name": "@zenyui/tiptap-react-render",
       "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
@@ -19,7 +19,6 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.13.5",
         "@types/react": "^19.0.10",
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zenyui/tiptap-react-render",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zenyui/tiptap-react-render",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.26.9",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@troop.com/tiptap-react-render",
+  "name": "@zenyui/tiptap-react-render",
   "version": "0.0.3",
   "description": "Render TipTap JSON in React without the editor!",
   "scripts": {
     "rollup": "rollup -c",
     "test": "jest"
   },
-  "author": "troop.com",
+  "author": "zenyui",
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.26.9",
@@ -39,6 +39,6 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/troop-dev/tiptap-react-render"
+    "url": "https://github.com/zenyui/tiptap-react-render"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenyui/tiptap-react-render",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Render TipTap JSON in React without the editor!",
   "scripts": {
     "rollup": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,15 @@
   "description": "Render TipTap JSON in React without the editor!",
   "scripts": {
     "rollup": "rollup -c",
-    "test": "jest"
+    "test": "jest",
+    "build": "rollup -c",
+    "prepublishOnly": "npm run build"
   },
   "author": "zenyui",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@babel/core": "^7.26.9",
     "@babel/preset-env": "^7.26.9",

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,17 @@
 # TipTap React Render
 
-[![npm](https://img.shields.io/npm/v/@troop.com/tiptap-react-render.svg?style=flat)](https://www.npmjs.com/package/@troop.com/tiptap-react-render)
-[![npm](https://img.shields.io/npm/dt/@troop.com/tiptap-react-render)](https://www.npmjs.com/package/@troop.com/tiptap-react-render)
+[![npm](https://img.shields.io/npm/v/@zenyui/tiptap-react-render.svg?style=flat)](https://www.npmjs.com/package/@zenyui/tiptap-react-render)
+[![npm](https://img.shields.io/npm/dt/@zenyui/tiptap-react-render)](https://www.npmjs.com/package/@zenyui/tiptap-react-render)
 
 This library renders [TipTap](https://tiptap.dev/) JSON payloads in React clients without embedding the editor.
 
 ### Installation
 ```sh
 # npm
-npm install @troop.com/tiptap-react-render
+npm install @zenyui/tiptap-react-render
 
 # yarn
-yarn add @troop.com/tiptap-react-render
+yarn add @zenyui/tiptap-react-render
 ```
 
 ### Usage

--- a/src/tip-tap-render.test.tsx
+++ b/src/tip-tap-render.test.tsx
@@ -160,7 +160,7 @@ describe("TipTapRender", () => {
       "link": link,
     }
     // paragraph with link in it
-    const url: string = "https://www.npmjs.com/package/@troop.com/tiptap-react-render"
+    const url: string = "https://www.npmjs.com/package/@zenyui/tiptap-react-render"
     const p1: TipTapNode = {
       type: "paragraph",
       content: [


### PR DESCRIPTION
- rename package to `@zenyui/tiptap-react-render`
- point author and repository url at zenyui
- add MIT `LICENSE.md` under zenyui copyright
- update readme npm badges and install instructions
- update sample url in tests